### PR TITLE
fix typo: interger → integer

### DIFF
--- a/crates/code_analysis/src/compilation/analyzer/doc/infer_type.rs
+++ b/crates/code_analysis/src/compilation/analyzer/doc/infer_type.rs
@@ -56,7 +56,7 @@ pub fn infer_type(analyzer: &mut DocAnalyzer, node: LuaDocType) -> LuaType {
                     }
                     LuaLiteralToken::Number(number_token) => {
                         if number_token.is_int() {
-                            return LuaType::DocIntergerConst(number_token.get_int_value());
+                            return LuaType::DocIntegerConst(number_token.get_int_value());
                         } else {
                             return LuaType::Number;
                         }

--- a/crates/code_analysis/src/db_index/type/humanize_type.rs
+++ b/crates/code_analysis/src/db_index/type/humanize_type.rs
@@ -24,13 +24,13 @@ pub fn humanize_type(db: &DbIndex, ty: &LuaType) -> String {
         LuaType::Union(union) => humanize_union_type(db, union),
         LuaType::Tuple(tuple) => humanize_tuple_type(db, tuple),
         LuaType::Unknown => "unknown".to_string(),
-        LuaType::Integer => "interger".to_string(),
+        LuaType::Integer => "integer".to_string(),
         LuaType::Io => "io".to_string(),
         LuaType::SelfInfer => "self".to_string(),
         LuaType::BooleanConst(b) => b.to_string(),
         LuaType::StringConst(s) => format!("\"{}\"", s),
         LuaType::DocStringConst(s) => format!("\"{}\"", s),
-        LuaType::DocIntergerConst(i) => i.to_string(),
+        LuaType::DocIntegerConst(i) => i.to_string(),
         LuaType::Ref(id) => {
             if let Some(type_decl) = db.get_type_index().get_type_decl(id) {
                 type_decl.get_name().to_string()

--- a/crates/code_analysis/src/db_index/type/types.rs
+++ b/crates/code_analysis/src/db_index/type/types.rs
@@ -54,7 +54,7 @@ pub enum LuaType {
     Instance(Arc<LuaInstanceType>),
     FuncTplRef(Arc<GenericTpl>),
     DocStringConst(ArcIntern<SmolStr>),
-    DocIntergerConst(i64),
+    DocIntegerConst(i64),
     Namespace(ArcIntern<SmolStr>),
 }
 
@@ -102,7 +102,7 @@ impl PartialEq for LuaType {
             (LuaType::Instance(a), LuaType::Instance(b)) => a == b,
             (LuaType::FuncTplRef(a), LuaType::FuncTplRef(b)) => a == b,
             (LuaType::DocStringConst(a), LuaType::DocStringConst(b)) => a == b,
-            (LuaType::DocIntergerConst(a), LuaType::DocIntergerConst(b)) => a == b,
+            (LuaType::DocIntegerConst(a), LuaType::DocIntegerConst(b)) => a == b,
             (LuaType::Namespace(a), LuaType::Namespace(b)) => a == b,
             _ => false, // 不同变体之间不相等
         }
@@ -176,7 +176,7 @@ impl Hash for LuaType {
             LuaType::Instance(a) => (38, a).hash(state),
             LuaType::FuncTplRef(a) => (39, a).hash(state),
             LuaType::DocStringConst(a) => (40, a).hash(state),
-            LuaType::DocIntergerConst(a) => (41, a).hash(state),
+            LuaType::DocIntegerConst(a) => (41, a).hash(state),
             LuaType::Namespace(a) => (42, a).hash(state),
         }
     }
@@ -221,7 +221,7 @@ impl LuaType {
     pub fn is_integer(&self) -> bool {
         matches!(
             self,
-            LuaType::IntegerConst(_) | LuaType::Integer | LuaType::DocIntergerConst(_)
+            LuaType::IntegerConst(_) | LuaType::Integer | LuaType::DocIntegerConst(_)
         )
     }
 
@@ -331,7 +331,7 @@ impl LuaType {
                 | LuaType::FloatConst(_)
                 | LuaType::TableConst(_)
                 | LuaType::DocStringConst(_)
-                | LuaType::DocIntergerConst(_)
+                | LuaType::DocIntegerConst(_)
         )
     }
 

--- a/crates/code_analysis/src/semantic/type_compact/mod.rs
+++ b/crates/code_analysis/src/semantic/type_compact/mod.rs
@@ -68,9 +68,9 @@ fn infer_type_compact(
         (LuaType::Integer, _) => compact_type.is_integer(),
         (LuaType::String, _) => compact_type.is_string(),
         (LuaType::Boolean, _) => compact_type.is_boolean(),
-        (LuaType::DocIntergerConst(i), _) => match compact_type {
+        (LuaType::DocIntegerConst(i), _) => match compact_type {
             LuaType::IntegerConst(j) => *i == j,
-            LuaType::DocIntergerConst(j) => *i == j,
+            LuaType::DocIntegerConst(j) => *i == j,
             _ => false,
         },
         (LuaType::DocStringConst(s), _) => match compact_type {

--- a/crates/emmylua_doc_cli/src/markdown_generator/render.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/render.rs
@@ -4,7 +4,7 @@ pub fn render_const_type(db: &DbIndex, typ: &LuaType) -> String {
     let const_value = humanize_type(db, typ);
 
     match typ {
-        LuaType::IntegerConst(_) | LuaType::DocIntergerConst(_) => {
+        LuaType::IntegerConst(_) | LuaType::DocIntegerConst(_) => {
             format!("integer = {}", const_value)
         }
         LuaType::FloatConst(_) => format!("number = {}", const_value),

--- a/crates/emmylua_ls/src/handlers/completion/providers/type_special_provider.rs
+++ b/crates/emmylua_ls/src/handlers/completion/providers/type_special_provider.rs
@@ -121,7 +121,7 @@ fn add_union_member_completion(
     for union_sub_typ in union_typ.get_types() {
         let name = match union_sub_typ {
             LuaType::DocStringConst(s) => to_enum_label(builder, s),
-            LuaType::DocIntergerConst(i) => i.to_string(),
+            LuaType::DocIntegerConst(i) => i.to_string(),
             _ => {
                 dispatch_type(builder, union_sub_typ.clone(), infer_guard);
                 continue;
@@ -188,7 +188,7 @@ fn add_alias_member_completion(
     let typ = member.get_decl_type();
     let name = match typ {
         LuaType::DocStringConst(s) => to_enum_label(builder, s),
-        LuaType::DocIntergerConst(i) => i.to_string(),
+        LuaType::DocIntegerConst(i) => i.to_string(),
         _ => return None,
     };
 

--- a/crates/emmylua_ls/src/handlers/hover/hover_humanize.rs
+++ b/crates/emmylua_ls/src/handlers/hover/hover_humanize.rs
@@ -5,7 +5,7 @@ pub fn hover_const_type(db: &DbIndex, typ: &LuaType) -> String {
     let const_value = humanize_type(db, typ);
 
     match typ {
-        LuaType::IntegerConst(_) | LuaType::DocIntergerConst(_) => {
+        LuaType::IntegerConst(_) | LuaType::DocIntegerConst(_) => {
             format!("integer = {}", const_value)
         }
         LuaType::FloatConst(_) => format!("number = {}", const_value),


### PR DESCRIPTION
Fix typos in hover and inline parameter type displays:

![image](https://github.com/user-attachments/assets/b72dccd6-a80d-4b6d-9d5d-43d5a16fe588)

![image](https://github.com/user-attachments/assets/9d38253c-beba-4fb7-993d-4562fe25bfb8)
