### PR TITLE
instantiate generics using the passed functions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,13 +64,13 @@ jobs:
         shell: pwsh
       - name: Upload
         if: ${{ matrix.cross != 'zigbuild'  }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           name: emmylua_ls-${{ matrix.platform }}
           path: ${{ github.workspace }}/artifact/
       - name: Upload zigbuild
         if: ${{ matrix.cross == 'zigbuild'  }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           name: emmylua_ls-${{ matrix.platform }}-glibc.${{ matrix.glibc }}
           path: ${{ github.workspace }}/artifact/
@@ -122,14 +122,14 @@ jobs:
           shell: pwsh
         - name: Upload
           if: ${{ matrix.cross != 'zigbuild'  }}
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with: 
             name: emmylua_doc_cli-${{ matrix.platform }}
             path: ${{ github.workspace }}/artifact/
         - name: Upload zigbuild
           if: ${{ matrix.cross == 'zigbuild'  }}
-          uses: actions/upload-artifact@v3
-          with: 
+          uses: actions/upload-artifact@v4
+          with:
             name: emmylua_doc_cli-${{ matrix.platform }}-glibc.${{ matrix.glibc }}
             path: ${{ github.workspace }}/artifact/
   release:
@@ -138,7 +138,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: zip windows package win32-x64
         uses: TheDoctor0/zip-release@v0.2.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 `CHG` refactor `semantic token`
 
+`NEW` support simple generic type instantiation based on the passed functions
+
 # 0.3.2
 
 `FIX` Fixed some multiple return value inference errors

--- a/crates/code_analysis/src/semantic/instantiate/tpl_pattern.rs
+++ b/crates/code_analysis/src/semantic/instantiate/tpl_pattern.rs
@@ -178,10 +178,32 @@ fn func_tpl_pattern_match(
 ) -> Option<()> {
     match target {
         LuaType::DocFunction(target_doc_func) => {
-            // todo
+            for i in 0..doc_func.get_params().len() {
+                let param_type = &doc_func.get_params()[i].clone().1?;
+                let target_param_type = &target_doc_func.get_params().get(i)?.clone().1?;
+                tpl_pattern_match(db, config, root, param_type, target_param_type, result);
+            }
+
+            for i in 0..doc_func.get_ret().len() {
+                let ret_type = &doc_func.get_ret()[i];
+                let target_ret_type = &target_doc_func.get_ret().get(i)?;
+                tpl_pattern_match(db, config, root, ret_type, target_ret_type, result);
+            }
         }
         LuaType::Signature(signature_id) => {
-            // todo
+            let signature = db.get_signature_index().get(&signature_id)?;
+
+            for i in 0..doc_func.get_params().len() {
+                let param_type = &doc_func.get_params()[i].clone().1?;
+                let target_param_type = &signature.param_docs.get(&i)?.type_ref;
+                tpl_pattern_match(db, config, root, param_type, target_param_type, result);
+            }
+
+            for i in 0..doc_func.get_ret().len() {
+                let ret_type = &doc_func.get_ret()[i];
+                let target_ret_type = &signature.return_docs.get(i)?.type_ref;
+                tpl_pattern_match(db, config, root, ret_type, target_ret_type, result);
+            }
         }
         _ => {}
     }


### PR DESCRIPTION
This patch adds simple type level matching for the doc functions and signatures allowing to instantiate generics based on the passed functions.

The following code demonstrates a generic type instantiated by this feature.
```lua
---@param a number
---@return string
local function tostr(a)
    return tostring(a)
end

---@generic T, U
---@param x T
---@param f fun(x: T): U
---@return U
local function apply(x, f)
    return f(x)
end

--"a" is inferred as a string.
a = apply(3, tostr)
```