### PR TITLE
bump upload artifact action to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,13 +64,13 @@ jobs:
         shell: pwsh
       - name: Upload
         if: ${{ matrix.cross != 'zigbuild'  }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           name: emmylua_ls-${{ matrix.platform }}
           path: ${{ github.workspace }}/artifact/
       - name: Upload zigbuild
         if: ${{ matrix.cross == 'zigbuild'  }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           name: emmylua_ls-${{ matrix.platform }}-glibc.${{ matrix.glibc }}
           path: ${{ github.workspace }}/artifact/
@@ -122,14 +122,14 @@ jobs:
           shell: pwsh
         - name: Upload
           if: ${{ matrix.cross != 'zigbuild'  }}
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with: 
             name: emmylua_doc_cli-${{ matrix.platform }}
             path: ${{ github.workspace }}/artifact/
         - name: Upload zigbuild
           if: ${{ matrix.cross == 'zigbuild'  }}
-          uses: actions/upload-artifact@v3
-          with: 
+          uses: actions/upload-artifact@v4
+          with:
             name: emmylua_doc_cli-${{ matrix.platform }}-glibc.${{ matrix.glibc }}
             path: ${{ github.workspace }}/artifact/
   release:
@@ -138,7 +138,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: zip windows package win32-x64
         uses: TheDoctor0/zip-release@v0.2.1
         with:


### PR DESCRIPTION
This patch bumps `actions/upload-artifact@v3` to `actions/upload-artifact@v4`. Now `v3` is deprecated [^1] which turned out to break #9.

[^1] https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/