### PR TITLE
fix loading configurations in NeoVim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 `CHG` refactor `template system`, optimize the generic infer
 
+`FIX` now configurations are loaded properly in NeoVim in cases when no extra LSP configuration parameters are provided
+
 # 0.3.3 
 
 `NEW` Add Develop Guide

--- a/crates/emmylua_ls/src/handlers/initialized/client_config/neovim_config.rs
+++ b/crates/emmylua_ls/src/handlers/initialized/client_config/neovim_config.rs
@@ -21,7 +21,10 @@ pub async fn get_client_config_neovim(
     let cancel_token = time_cancel_token(Duration::from_secs(5));
     let configs = client
         .get_configuration::<Value>(params, cancel_token)
-        .await?;
+        .await?
+        .into_iter()
+        .filter(|config| !config.is_null())
+        .collect();
 
     if let Some(pretty_json) = serde_json::to_string_pretty(&configs).ok() {
         info!("load neovim client config: {}", pretty_json);


### PR DESCRIPTION
This patch fixes loading configurations in NeoVim in cases when no extra
LSP config parameters are provided. After loading Emmyrc configs
they were merged with partial Emmyrcs loaded based on the LSP config
in NeoVim. If LSP hasn't got configuration section configured you came
into a situation with only Null object partial Emmyrc overwriting
the local Emmyrc configuration.

Let's ignore Null LSP configurations (i.e. unprovided ones) to prevent
them from completely overwriting other configurations when loading
NeoVim LSP configuration options.