### PR TITLE
extend const table type humanization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 `FIX` now configurations are loaded properly in NeoVim in cases when no extra LSP configuration parameters are provided
 
+`CHG` extended humanization of small constant table types
+
 # 0.3.3 
 
 `NEW` Add Develop Guide


### PR DESCRIPTION
This patch extends the humanized variant of the const table. Previously, every constant table has been displayed as `table`. This patch makes short constant tables (having full type name no more than 36 symbols length) humanize into preciser types. See the following examples.

```lua
-- a is humanized like `{ [1] = "test", [3] = 4 }`
local a = { [1] = 'test', [3] = 4 }
-- b is humanized like `{ name = "Pete", age = 36 }`
local b = { name = 'pete', age = 36 }
-- c is humanized like `{ a = table }`
local c = { a = { very_very_very_very_very_long = 10000 } }
-- d is humanized like `table`
local d = { very_very_very_very_very_long = 10000 }
```