### PR TITLE
add basic table field names autocompletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 `NEW` support `code style check`, which powered by `emmyluacodestyle`
 
+`NEW` Basic table declaration field names autocompletion.
+
 # 0.4.3
 
 `FIX` Fix std resource loaded for cli tools

--- a/crates/emmylua_ls/src/handlers/completion/add_completions/add_member_completion.rs
+++ b/crates/emmylua_ls/src/handlers/completion/add_completions/add_member_completion.rs
@@ -12,6 +12,7 @@ use super::{
 pub enum CompletionTriggerStatus {
     Dot,
     Colon,
+    InTable,
     InString,
     LeftBracket,
 }
@@ -41,6 +42,10 @@ pub fn add_member_completion(
             _ => return None,
         },
         CompletionTriggerStatus::InString => match member_key {
+            LuaMemberKey::Name(name) => name.to_string(),
+            _ => return None,
+        },
+        CompletionTriggerStatus::InTable => match member_key {
             LuaMemberKey::Name(name) => name.to_string(),
             _ => return None,
         },

--- a/crates/emmylua_ls/src/handlers/completion/providers/mod.rs
+++ b/crates/emmylua_ls/src/handlers/completion/providers/mod.rs
@@ -9,6 +9,7 @@ mod member_provider;
 mod module_path_provider;
 mod auto_require_provider;
 mod postfix_provider;
+mod table_decl_field_provider;
 
 use super::completion_builder::CompletionBuilder;
 
@@ -16,6 +17,7 @@ pub fn add_completions(builder: &mut CompletionBuilder) -> Option<()> {
     module_path_provider::add_completion(builder);
     file_path_provider::add_completion(builder);
     keywords_provider::add_completion(builder);
+    table_decl_field_provider::add_completion(builder);
     type_special_provider::add_completion(builder);
     env_provider::add_completion(builder);
     member_provider::add_completion(builder);

--- a/crates/emmylua_ls/src/handlers/completion/providers/table_decl_field_provider.rs
+++ b/crates/emmylua_ls/src/handlers/completion/providers/table_decl_field_provider.rs
@@ -1,0 +1,47 @@
+use std::collections::HashSet;
+
+use emmylua_parser::{LuaAst, LuaAstToken, LuaAstNode, LuaTableExpr, LuaNameExpr, LuaTableField, LuaNameToken, LuaCallExpr, LuaCallArgList};
+use emmylua_code_analysis::LuaType;
+
+use crate::handlers::completion::{
+    add_completions::{add_member_completion, CompletionTriggerStatus},
+    completion_builder::CompletionBuilder,
+};
+
+pub fn add_completion(builder: &mut CompletionBuilder) -> Option<()> {
+    let table_expr = LuaNameToken::cast(builder.trigger_token.clone())?
+        .get_parent::<LuaNameExpr>()?
+        .get_parent::<LuaTableField>()?
+        .get_parent::<LuaTableExpr>()?;
+
+    // todo non-function completion (e.g. in other tables)
+    // todo support parents which types are inferred implicitly
+    let table_type = match table_expr.get_parent()? {
+        | LuaAst::LuaCallArgList(call_arg_list) => get_table_type_by_calleee(builder, call_arg_list, LuaAst::LuaTableExpr(table_expr)),
+        | _ => { None },
+    }?;
+
+    let mut duplicated_set = HashSet::new();
+    let member_infos = builder.semantic_model.infer_member_infos(&table_type)?;
+    for member_info in member_infos {
+        if duplicated_set.contains(&member_info.key) {
+            continue;
+        }
+
+        duplicated_set.insert(member_info.key.clone());
+        add_member_completion(builder, member_info, CompletionTriggerStatus::InTable);
+    }
+
+    Some(())
+}
+
+fn get_table_type_by_calleee(builder: &mut CompletionBuilder, call_arg_list: LuaCallArgList, table_expr: LuaAst) -> Option<LuaType> {
+    let call_expr = call_arg_list.get_parent::<LuaCallExpr>()?;
+    let func_type = builder.semantic_model.infer_call_expr_func(call_expr.clone(), None)?;
+    let param_types = func_type.get_params();
+    let call_arg_number = call_arg_list.children::<LuaAst>().into_iter().enumerate().find(|(_, arg)| *arg == table_expr)?.0;
+    let table_type = param_types.get(call_arg_number)?.1.clone();
+
+    return table_type;
+}
+


### PR DESCRIPTION
This patch adds basic autocompletion features for table field names when declaring a table.

Example.
```lua
---@class Bar: table
---@field buz number

---@param a Bar
local function foo(a)
end

foo({
    -- `buz` field is suggested here...
})
```

The implementation is very basic. Known limitations are the following.
* The field names are suggested only when the table is instantiated within the function arguments with defined types.
* Generics/inferred funkjction types aren't supported yet.

Closes #20