### PR TITLE
fix possible panic when calculating pow values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 `NEW` Basic table declaration field names autocompletion.
 
+`FIX` Fix possible panic due to integer overflow when calculating pows.
+
 # 0.4.3
 
 `FIX` Fix std resource loaded for cli tools

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_binary.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_binary.rs
@@ -240,7 +240,11 @@ fn infer_binary_expr_pow(db: &DbIndex, left: LuaType, right: LuaType) -> InferRe
     if left.is_number() && right.is_number() {
         return match (&left, &right) {
             (LuaType::IntegerConst(int1), LuaType::IntegerConst(int2)) => {
-                Some(LuaType::IntegerConst(int1.pow(*int2 as u32)))
+                if let Some(int3) = int1.checked_pow(*int2 as u32) {
+                    Some(LuaType::IntegerConst(int3))
+                } else {
+                    Some(LuaType::Number)
+                }
             }
             (LuaType::FloatConst(num1), LuaType::IntegerConst(num2)) => {
                 Some(LuaType::FloatConst(num1.powf(*num2 as f64).into()))


### PR DESCRIPTION
This patch fixes possible LSP panic that occurs when LSP type inferer power calculations overflowed the `i64` value upper bound.

The fix is straightforward: replace the `pow()` call that may throw an exception with safe `checked_pow()`.