### PR TITLE
add support for `workspace.library` in check tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 `NEW` Support compile by winodws mingw
 
+`NEW` `emmylua_check` now supports `workspace.library`
+
 # 0.4.3
 
 `FIX` Fix std resource loaded for cli tools


### PR DESCRIPTION
This patch adds support for `workspace.library` option in check tool. The directory is loaded with the same code used within the language server. The implementation is very straightforward and is subject to change.