### PR TITLE
add function parameter types to completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 0.4.5(unreleased)
 
+`NEW` Function completion suggestions now contain type parameters.
 
 # 0.4.4
 

--- a/crates/emmylua_ls/src/handlers/completion/add_completions/mod.rs
+++ b/crates/emmylua_ls/src/handlers/completion/add_completions/mod.rs
@@ -80,7 +80,13 @@ fn get_detail(
             let mut params_str = signature
                 .get_type_params()
                 .iter()
-                .map(|param| param.0.clone())
+                .map(|param| {
+                    if let Some(param_type) = &param.1 {
+                        format!("{}: {}", param.0.clone(), humanize_type(builder.semantic_model.get_db(), param_type))
+                    } else {
+                        format!("{}", param.0.clone())
+                    }
+                })
                 .collect::<Vec<_>>();
 
             match display {


### PR DESCRIPTION
This patch adds function parameter types to completion suggestions to make it easier for user to understand the parameter type. For instance.

```lua
---@param a number
local function test(a) end
```

Previous suggestion: `test Function (a)`.
New suggestion: `test Function (a: number)`.