### PR TITLE
infer constant array tables as tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 `NEW` Compact luals env variable start with `$`
 
+`FIX` Refactor `humanize type` for stack overflow issue
+
+`Fix` Fix a documentation cli tool render issue
+
 # 0.4.4
 
 `NEW` Support generic alias fold

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 `Fix` Fix a documentation cli tool render issue
 
+`NEW` Constant array tables are now inferred as tuples of elements
+
 # 0.4.4
 
 `NEW` Support generic alias fold

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [workspace.dependencies]
 # local
 emmylua_code_analysis = { path = "crates/emmylua_code_analysis", version = "0.4.0" }
-emmylua_parser = { path = "crates/emmylua_parser", version = "0.9.1" }
+emmylua_parser = { path = "crates/emmylua_parser", version = "0.9.2" }
 emmylua_diagnostic_macro = { path = "crates/emmylua_diagnostic_macro", version = "0.4.0" }
 
 # external

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_table.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_table.rs
@@ -1,12 +1,24 @@
 use emmylua_parser::{LuaAstNode, LuaTableExpr};
 
-use crate::db_index::{DbIndex, LuaType};
+use crate::db_index::{DbIndex, LuaType, LuaTupleType};
 
-use super::{InferResult, LuaInferConfig};
+use super::{InferResult, LuaInferConfig, infer_expr};
 
-pub fn infer_table_expr(_: &DbIndex, config: &LuaInferConfig, table: LuaTableExpr) -> InferResult {
-    Some(LuaType::TableConst(crate::InFiled {
-        file_id: config.get_file_id(),
-        value: table.get_range(),
-    }))
+pub fn infer_table_expr(db: &DbIndex, config: &mut LuaInferConfig, table: LuaTableExpr) -> InferResult {
+    if table.is_array() {
+        infer_table_array_expr(db, config, table)
+    } else {
+        Some(LuaType::TableConst(crate::InFiled {
+            file_id: config.get_file_id(),
+            value: table.get_range(),
+        }))
+    }
+}
+
+fn infer_table_array_expr(db: &DbIndex, config: &mut LuaInferConfig, table: LuaTableExpr) -> InferResult {
+    let field_types = table.get_fields()
+        .map(|field| infer_expr(db, config, field.get_value_expr()?))
+        .map(|field_type| field_type.unwrap_or(LuaType::Unknown))
+        .collect::<Vec<_>>();
+    Some(LuaTupleType::new(field_types).into())
 }


### PR DESCRIPTION
This patch makes LSP infer constant array tables as tuples of elements.

Example.
```lua
-- Inferred `(1, 2)`
local a = {1, 2}

-- Inferred `("test",(3,4))`
local b = {'test', {3, 4}}
```

Thus, making preciser inference of indexing statements.

```lua
--- Inferred `4`
local c = b[2][1]
```

Closes #40