### PR TITLE
support array and tuple compatibility comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # 0.4.7(unreleased)
 
+`NEW` Support type-check when casting tuples to arrays.
+
 # 0.4.6
 
 `FIX` Fix issue with executable file directory hierarchy being too deep.


### PR DESCRIPTION
This patch adds support for comparing array and tuple types. Basically, the code just asserts every element of a tuple is just the same as the array element when casting `tuple -> array`.

```lua
---@param a number[]
local function test(a) end

---@type [number, number]
local foo = {1, 2}

---@type [number, string]
local bar = {1, 'test'}

test(foo) -- OK
test(bar) -- Not OK
```

Note that the allowed conversions doesn't work in the `array -> tuple` direction.

```lua
---@param a [number, number]
local function test2(a) end

---@type number[]
local buz = {1, 2}

-- A warning is thrown, likely this is a mistake since the length of the
-- array is arbitrary.
test2(buz)
```