### PR TITLE
add function overload completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 `NEW` Support type-check when casting tuples to arrays.
 
+`NEW` Now autocompletion suggests function overloads.
+
 # 0.4.6
 
 `FIX` Fix issue with executable file directory hierarchy being too deep.


### PR DESCRIPTION
This patch adds completions for functions overloads. Basically it just adds extra function signatures.

For instance, when you write `table.ins...` you receive the following completions.
```
insert FUNCTION (list, pos, value)number
insert FUNCTION (list, value)number
```