### PR TITLE
improve annotations for tonumber()

### DIFF
--- a/crates/emmylua_code_analysis/resources/std/global.lua
+++ b/crates/emmylua_code_analysis/resources/std/global.lua
@@ -344,10 +344,15 @@ function setmetatable(table, metatable) end
 --- represents 10, 'B' represents 11, and so forth, with 'Z' representing 35. If
 --- the string `e` is not a valid numeral in the given base, the function
 --- returns **nil**.
----@overload fun(e:string|number):number
----@param e string|number
+---@overload fun(e:number):number
+---@overload fun(e:number, base: int):number
+---@overload fun(e:string):number|nil
+---@overload fun(e:string, base: int):number|nil
+---@overload fun(e:any):nil
+---@overload fun(e:any, base:int):nil
+---@param e any
 ---@param base? int
----@return number
+---@return number|nil
 function tonumber(e, base) end
 
 ---


### PR DESCRIPTION
With this change: 
```lua
local a = tonumber(1) -- number
local b = tonumber('1') -- (number|nil)
local c = tonumber(nil) -- nil
local d = tonumber({}) -- nil
local e = tonumber('1', 10) -- (number|nil)
local f = tonumber(nil, 10) -- nil
local g = tonumber(1, 10) -- number
```

Quite possible that there's some redundant ones and/or can be improved further