### PR TITLE
添加env标记功能，env标记具有以下功能：

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/analyzer/decl/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/decl/mod.rs
@@ -87,6 +87,9 @@ fn walk_node_enter(analyzer: &mut DeclAnalyzer, node: LuaAst) {
         LuaAst::LuaDocTagClass(doc_tag) => {
             docs::analyze_doc_tag_class(analyzer, doc_tag);
         }
+        LuaAst::LuaDocTagEnv(doc_tag) => {
+            docs::analyze_doc_tag_env(analyzer, doc_tag);
+        }
         LuaAst::LuaDocTagEnum(doc_tag) => {
             docs::analyze_doc_tag_enum(analyzer, doc_tag);
         }

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/lua/module.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/lua/module.rs
@@ -1,6 +1,10 @@
 use emmylua_parser::LuaChunk;
 
-use crate::{compilation::analyzer::unresolve::UnResolveModule, db_index::LuaType};
+use crate::{
+    compilation::analyzer::unresolve::UnResolveModule, 
+    db_index::{LuaMember, LuaMemberKey, LuaMemberOwner, LuaType},
+    LuaDeclExtra
+};
 
 use super::{func_body::analyze_func_body_returns, LuaAnalyzer, LuaReturnPoint};
 
@@ -42,6 +46,78 @@ pub fn analyze_chunk_return(analyzer: &mut LuaAnalyzer, chunk: LuaChunk) -> Opti
             // Other cases are stupid code
             _ => {}
         }
+    }
+
+    Some(())
+}
+
+pub fn analyze_chunk_env(analyzer: &mut LuaAnalyzer, name: String) -> Option<()> {
+    let file_id = analyzer.file_id;
+
+    let env_decl_id = {
+        let env_decl = analyzer
+            .db
+            .get_type_index()
+            .find_type_decl(analyzer.file_id, &name)?;
+
+        if !env_decl.is_env() {
+            return None;
+        }
+        env_decl.get_id()
+    };
+
+    // 修正文件返回值类型为申明的 env
+    let module_info = analyzer
+        .db
+        .get_module_index_mut()
+        .get_module_mut(analyzer.file_id)?;
+
+    module_info.export_type = Some(LuaType::Def(env_decl_id.clone()));
+
+    // 将文件内所有全局变量转换为env的变量
+    if let Some(decl_tree) = analyzer.db.get_decl_index_mut().get_decl_tree(&file_id){
+        let owner =  LuaMemberOwner::Type(env_decl_id);
+
+        let mut decl_list = Vec::new();
+
+        for (decl_id, decl) in decl_tree.get_decls().clone() {
+            if decl.is_global() {
+                decl_list.push(decl_id);
+
+                let name = decl.get_name();
+
+                // 删除全局标记
+                analyzer.db.get_reference_index_mut().remove_global_reference(name);
+                analyzer.db.get_decl_index_mut().remove_global_decl(name);
+
+                let decl_type = match decl.extra.clone() {
+                    LuaDeclExtra::Global { kind:_, decl_type } => {
+                        decl_type
+                    }
+                    _ => None
+                };
+
+                let member = LuaMember::new(
+                    LuaMemberOwner::None, 
+                    LuaMemberKey::Name(name.into()), 
+                    file_id, 
+                    decl.get_syntax_id(), 
+                    decl_type);
+                let member_id = member.get_id();
+
+                // 添加到env的成员列表
+                analyzer.db.get_member_index_mut().add_member(member);
+                analyzer.db.get_member_index_mut().add_member_owner(owner.clone(), member_id);
+            }
+        }
+
+        for decl_id in decl_list {
+            // 标记该decl不再是全局变量
+            if let Some(decl) = analyzer.db.get_decl_index_mut().get_decl_mut(&decl_id) {
+                decl.set_local();
+            }
+        }
+        
     }
 
     Some(())

--- a/crates/emmylua_code_analysis/src/db_index/declaration/decl.rs
+++ b/crates/emmylua_code_analysis/src/db_index/declaration/decl.rs
@@ -115,6 +115,19 @@ impl LuaDecl {
     pub fn is_global(&self) -> bool {
         matches!(&self.extra, LuaDeclExtra::Global { .. })
     }
+
+    pub fn set_local(&mut self) {
+        match &self.extra {
+            LuaDeclExtra::Global { kind, decl_type } => {
+                self.extra = LuaDeclExtra::Local {
+                    kind: *kind,
+                    decl_type: decl_type.clone(),
+                    attrib: None,
+                };
+            }
+            _ => {}
+        }
+    }
 }
 
 #[derive(Eq, PartialEq, Hash, Debug, Clone, Copy)]

--- a/crates/emmylua_code_analysis/src/db_index/declaration/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/declaration/mod.rs
@@ -35,6 +35,14 @@ impl LuaDeclIndex {
             .push(decl_id);
     }
 
+    pub fn remove_global_decl(&mut self, name: &str) {
+        let key = SmolStr::new(name);
+        let key = LuaMemberKey::Name(key);
+        if self.global_decl.contains_key(&key) {
+            self.global_decl.remove(&key);
+        }
+    }
+
     pub fn add_decl_tree(&mut self, tree: LuaDeclarationTree) {
         self.decl_trees.insert(tree.file_id(), tree);
     }

--- a/crates/emmylua_code_analysis/src/db_index/reference/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/reference/mod.rs
@@ -54,6 +54,13 @@ impl LuaReferenceIndex {
             .insert(syntax_id);
     }
 
+    pub fn remove_global_reference(&mut self, name: &str) {
+        let key = SmolStr::new(name);
+        if self.global_references.contains_key(&key) {
+            self.global_references.remove(&key);
+        }
+    }
+
     pub fn add_index_reference(
         &mut self,
         key: LuaMemberKey,

--- a/crates/emmylua_code_analysis/src/db_index/type/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/mod.rs
@@ -23,6 +23,7 @@ pub use types::*;
 pub struct LuaTypeIndex {
     file_namespace: HashMap<FileId, String>,
     file_using_namespace: HashMap<FileId, Vec<String>>,
+    file_env: HashMap<FileId, String>,
     file_types: HashMap<FileId, Vec<LuaTypeDeclId>>,
     full_name_type_map: HashMap<LuaTypeDeclId, LuaTypeDecl>,
     generic_params: HashMap<LuaTypeDeclId, Vec<(String, Option<LuaType>)>>,
@@ -35,6 +36,7 @@ impl LuaTypeIndex {
         Self {
             file_namespace: HashMap::new(),
             file_using_namespace: HashMap::new(),
+            file_env: HashMap::new(),
             file_types: HashMap::new(),
             full_name_type_map: HashMap::new(),
             generic_params: HashMap::new(),
@@ -60,6 +62,14 @@ impl LuaTypeIndex {
 
     pub fn get_file_using_namespace(&self, file_id: &FileId) -> Option<&Vec<String>> {
         self.file_using_namespace.get(file_id)
+    }
+
+    pub fn add_file_env(&mut self, file_id: FileId, env: String) {
+        self.file_env.insert(file_id, env);
+    }
+
+    pub fn get_file_env(&self, file_id: &FileId) -> Option<&String> {
+        self.file_env.get(file_id)
     }
 
     pub fn add_type_decl(

--- a/crates/emmylua_code_analysis/src/db_index/type/type_decl.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_decl.rs
@@ -13,6 +13,7 @@ pub enum LuaDeclTypeKind {
     Class,
     Enum,
     Alias,
+    Env,
 }
 
 flags! {
@@ -52,6 +53,7 @@ impl LuaTypeDecl {
             extra: match kind {
                 LuaDeclTypeKind::Enum => Box::new(LuaTypeExtra::Enum { base: None }),
                 LuaDeclTypeKind::Class => Box::new(LuaTypeExtra::Class),
+                LuaDeclTypeKind::Env => Box::new(LuaTypeExtra::Env),
                 LuaDeclTypeKind::Alias => Box::new(LuaTypeExtra::Alias {
                     origin: None,
                     union: None,
@@ -85,6 +87,7 @@ impl LuaTypeDecl {
             LuaTypeExtra::Enum { .. } => LuaDeclTypeKind::Enum,
             LuaTypeExtra::Class => LuaDeclTypeKind::Class,
             LuaTypeExtra::Alias { .. } => LuaDeclTypeKind::Alias,
+            LuaTypeExtra::Env => LuaDeclTypeKind::Env,
         }
     }
 
@@ -98,6 +101,10 @@ impl LuaTypeDecl {
 
     pub fn is_alias(&self) -> bool {
         matches!(&*self.extra, LuaTypeExtra::Alias { .. })
+    }
+
+    pub fn is_env(&self) -> bool {
+        matches!(&*self.extra, LuaTypeExtra::Env)
     }
 
     pub fn get_attrib(&self) -> Option<FlagSet<LuaTypeAttribute>> {
@@ -273,6 +280,7 @@ pub enum LuaTypeExtra {
         base: Option<LuaType>,
     },
     Class,
+    Env,
     Alias {
         origin: Option<LuaType>,
         union: Option<Vec<LuaMemberId>>,

--- a/crates/emmylua_ls/src/handlers/semantic_token/build_semantic_tokens.rs
+++ b/crates/emmylua_ls/src/handlers/semantic_token/build_semantic_tokens.rs
@@ -107,6 +107,7 @@ fn build_tokens_semantic_token(
             builder.push(token, SemanticTokenType::NUMBER);
         }
         LuaTokenKind::TkTagClass
+        | LuaTokenKind::TKTagEnv
         | LuaTokenKind::TkTagEnum
         | LuaTokenKind::TkTagInterface
         | LuaTokenKind::TkTagAlias
@@ -227,6 +228,13 @@ fn build_node_semantic_token(
                     }
                 }
             }
+        }
+        LuaAst::LuaDocTagEnv(doc_env) => {
+            let name = doc_env.get_name_token()?;
+            builder.push_with_modifier(
+                name.syntax().clone(), 
+                SemanticTokenType::KEYWORD, 
+            SemanticTokenModifier::DOCUMENTATION);
         }
         LuaAst::LuaDocTagEnum(doc_enum) => {
             let name = doc_enum.get_name_token()?;

--- a/crates/emmylua_parser/src/grammar/doc/tag.rs
+++ b/crates/emmylua_parser/src/grammar/doc/tag.rs
@@ -33,6 +33,7 @@ fn parse_tag_detail(p: &mut LuaDocParser) -> ParseResult {
     match p.current_token() {
         // main tag
         LuaTokenKind::TkTagClass | LuaTokenKind::TkTagInterface => parse_tag_class(p),
+        LuaTokenKind::TKTagEnv => parse_tag_env(p),
         LuaTokenKind::TkTagEnum => parse_tag_enum(p),
         LuaTokenKind::TkTagAlias => parse_tag_alias(p),
         LuaTokenKind::TkTagField => parse_tag_field(p),
@@ -97,6 +98,17 @@ fn parse_tag_class(p: &mut LuaDocParser) -> ParseResult {
 
     p.set_state(LuaDocLexerState::Description);
     parse_description(p);
+    Ok(m.complete(p))
+}
+
+// ---@env <env name>
+fn parse_tag_env(p: &mut LuaDocParser) -> ParseResult {
+    // parse_tag_simple(p, LuaSyntaxKind::DocTagEnv)
+
+    p.set_state(LuaDocLexerState::Normal);
+    let m = p.mark(LuaSyntaxKind::DocTagEnv);
+    p.bump();
+    expect_token(p, LuaTokenKind::TkName)?;
     Ok(m.complete(p))
 }
 

--- a/crates/emmylua_parser/src/kind/lua_syntax_kind.rs
+++ b/crates/emmylua_parser/src/kind/lua_syntax_kind.rs
@@ -56,6 +56,7 @@ pub enum LuaSyntaxKind {
 
     // doc tag
     DocTagClass,
+    DocTagEnv,
     DocTagEnum,
     DocTagInterface,
     DocTagAlias,

--- a/crates/emmylua_parser/src/kind/lua_token_kind.rs
+++ b/crates/emmylua_parser/src/kind/lua_token_kind.rs
@@ -88,6 +88,7 @@ pub enum LuaTokenKind {
 
     // tag
     TkTagClass,     // class
+    TKTagEnv,       // env
     TkTagEnum,      // enum
     TkTagInterface, // interface
     TkTagAlias,     // alias

--- a/crates/emmylua_parser/src/lexer/lua_doc_lexer.rs
+++ b/crates/emmylua_parser/src/lexer/lua_doc_lexer.rs
@@ -478,6 +478,7 @@ impl LuaDocLexer<'_> {
 fn to_tag(text: &str) -> LuaTokenKind {
     match text {
         "class" => LuaTokenKind::TkTagClass,
+        "env" => LuaTokenKind::TKTagEnv,
         "enum" => LuaTokenKind::TkTagEnum,
         "interface" => LuaTokenKind::TkTagInterface,
         "alias" => LuaTokenKind::TkTagAlias,

--- a/crates/emmylua_parser/src/syntax/node/doc/tag.rs
+++ b/crates/emmylua_parser/src/syntax/node/doc/tag.rs
@@ -13,6 +13,7 @@ use super::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum LuaDocTag {
     Class(LuaDocTagClass),
+    Env(LuaDocTagEnv),
     Enum(LuaDocTagEnum),
     Alias(LuaDocTagAlias),
     Type(LuaDocTagType),
@@ -44,6 +45,7 @@ impl LuaAstNode for LuaDocTag {
     fn syntax(&self) -> &LuaSyntaxNode {
         match self {
             LuaDocTag::Class(it) => it.syntax(),
+            LuaDocTag::Env(it) => it.syntax(),
             LuaDocTag::Enum(it) => it.syntax(),
             LuaDocTag::Alias(it) => it.syntax(),
             LuaDocTag::Type(it) => it.syntax(),
@@ -111,6 +113,9 @@ impl LuaAstNode for LuaDocTag {
         match syntax.kind().into() {
             LuaSyntaxKind::DocTagClass => {
                 Some(LuaDocTag::Class(LuaDocTagClass::cast(syntax).unwrap()))
+            }
+            LuaSyntaxKind::DocTagEnv => {
+                Some(LuaDocTag::Env(LuaDocTagEnv::cast(syntax).unwrap()))
             }
             LuaSyntaxKind::DocTagEnum => {
                 Some(LuaDocTag::Enum(LuaDocTagEnum::cast(syntax).unwrap()))
@@ -233,6 +238,47 @@ impl LuaDocTagClass {
     }
 
     pub fn get_attrib(&self) -> Option<LuaDocAttribute> {
+        self.child()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LuaDocTagEnv {
+    syntax: LuaSyntaxNode,
+}
+
+impl LuaAstNode for LuaDocTagEnv {
+    fn syntax(&self) -> &LuaSyntaxNode {
+        &self.syntax
+    }
+
+    fn can_cast(kind: LuaSyntaxKind) -> bool
+    where
+        Self: Sized,
+    {
+        kind == LuaSyntaxKind::DocTagEnv
+    }
+
+    fn cast(syntax: LuaSyntaxNode) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if Self::can_cast(syntax.kind().into()) {
+            Some(Self { syntax })
+        } else {
+            None
+        }
+    }
+}
+
+impl LuaDocDescriptionOwner for LuaDocTagEnv {}
+
+impl LuaDocTagEnv {
+    pub fn get_name_token(&self) -> Option<LuaNameToken> {
+        self.token()
+    }
+
+    pub fn get_type(&self) -> Option<LuaDocType> {
         self.child()
     }
 }

--- a/crates/emmylua_parser/src/syntax/node/mod.rs
+++ b/crates/emmylua_parser/src/syntax/node/mod.rs
@@ -61,6 +61,7 @@ pub enum LuaAst {
     LuaComment(LuaComment),
     // doc tag
     LuaDocTagClass(LuaDocTagClass),
+    LuaDocTagEnv(LuaDocTagEnv),
     LuaDocTagEnum(LuaDocTagEnum),
     LuaDocTagAlias(LuaDocTagAlias),
     LuaDocTagType(LuaDocTagType),
@@ -143,6 +144,7 @@ impl LuaAstNode for LuaAst {
             LuaAst::LuaElseIfClauseStat(node) => node.syntax(),
             LuaAst::LuaElseClauseStat(node) => node.syntax(),
             LuaAst::LuaDocTagClass(node) => node.syntax(),
+            LuaAst::LuaDocTagEnv(node) => node.syntax(),
             LuaAst::LuaDocTagEnum(node) => node.syntax(),
             LuaAst::LuaDocTagAlias(node) => node.syntax(),
             LuaAst::LuaDocTagType(node) => node.syntax(),
@@ -226,6 +228,7 @@ impl LuaAstNode for LuaAst {
             LuaSyntaxKind::ElseClauseStat => true,
             LuaSyntaxKind::Comment => true,
             LuaSyntaxKind::DocTagClass => true,
+            LuaSyntaxKind::DocTagEnv => true,
             LuaSyntaxKind::DocTagEnum => true,
             LuaSyntaxKind::DocTagAlias => true,
             LuaSyntaxKind::DocTagType => true,
@@ -324,6 +327,7 @@ impl LuaAstNode for LuaAst {
                 LuaElseClauseStat::cast(syntax).map(LuaAst::LuaElseClauseStat)
             }
             LuaSyntaxKind::DocTagClass => LuaDocTagClass::cast(syntax).map(LuaAst::LuaDocTagClass),
+            LuaSyntaxKind::DocTagEnv => LuaDocTagEnv::cast(syntax).map(LuaAst::LuaDocTagEnv),
             LuaSyntaxKind::DocTagEnum => LuaDocTagEnum::cast(syntax).map(LuaAst::LuaDocTagEnum),
             LuaSyntaxKind::DocTagAlias => LuaDocTagAlias::cast(syntax).map(LuaAst::LuaDocTagAlias),
             LuaSyntaxKind::DocTagType => LuaDocTagType::cast(syntax).map(LuaAst::LuaDocTagType),


### PR DESCRIPTION
1. 使用格式是 ---@env <name>，是一种新的申明类型的方式
2. 当文件存在env标记的时候，该文件下面的所有全局变量会转变成env申明的类型的member，并且删除他们在全局数据里面的标价