### PR TITLE
fix: list Lua 5.2 as having support for pow operator

### DIFF
--- a/crates/emmylua_parser/src/lexer/lexer_config.rs
+++ b/crates/emmylua_parser/src/lexer/lexer_config.rs
@@ -38,7 +38,10 @@ impl LexerConfig {
     pub fn support_pow_operator(&self) -> bool {
         matches!(
             self.language_level,
-            LuaLanguageLevel::Lua53 | LuaLanguageLevel::Lua54 | LuaLanguageLevel::LuaJIT
+            LuaLanguageLevel::Lua52
+                | LuaLanguageLevel::Lua53
+                | LuaLanguageLevel::Lua54
+                | LuaLanguageLevel::LuaJIT
         )
     }
 }


### PR DESCRIPTION
References:
- https://www.lua.org/manual/5.2/manual.html#3.4.1
- https://www.lua.org/source/5.2/lopcodes.h.html#OP_POW

```
Lua 5.2.4  Copyright (C) 1994-2015 Lua.org, PUC-Rio
> print(13 ^ 4)
28561
> print(math.pow(13, 4))
28561
```