### PR TITLE
infer for range vars from aliases and overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 `NEW` Compact luals fun return syntax like: `(name: string, age: number)`
 
+`NEW` Aliases and overloads of iterator functions (i.e `fun(v: any): (K, V)` where `K` is the key type and `V` is the value type) are now used to infer types in `for` loops
+
 # 0.5.4
 
 `Fix` Fix generic dots params type check

--- a/crates/emmylua_code_analysis/src/compilation/test/for_range_var_infer_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/for_range_var_infer_test.rs
@@ -1,0 +1,40 @@
+#[cfg(test)]
+mod test {
+    use crate::{LuaType, VirtualWorkspace};
+
+    #[test]
+    fn test_closure_param_infer() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+        ---@alias foo (fun(tbl: any): (number, string))
+
+        ---@type foo
+        local b = {}
+
+        for k3, v3 in b do
+            k1 = k3
+            v1 = v3
+        end
+
+
+        ---@class bar
+        ---@overload fun(tbl: any): (number, string)
+
+        ---@type bar
+        local c = {}
+
+        for k4, v4 in c do
+            k2 = k4
+            v2 = v4
+        end
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("k1"), LuaType::Number);
+        assert_eq!(ws.expr_ty("v1"), LuaType::String);
+        assert_eq!(ws.expr_ty("k2"), LuaType::Number);
+        assert_eq!(ws.expr_ty("v2"), LuaType::String);
+    }
+}

--- a/crates/emmylua_code_analysis/src/compilation/test/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/mod.rs
@@ -1,6 +1,7 @@
 mod closure_param_infer_test;
 mod closure_return_test;
 mod flow;
+mod for_range_var_infer_test;
 mod inherit_type;
 mod mathlib_test;
 mod multi_return;


### PR DESCRIPTION
This patch adds support for deriving for-range loop variables from the
iterator types specified as aliases and class overloads.

I.e. you may alias `fun(v: any): K, V` and if you try to iterate through
the instance of this type the loop variables will be inferred as `K, V`.
If the class provide a function overload it's also used for type
inference.

It might be helpful for writing complex functional libraries for
determining custom iterators.

Example.

```lua
---@alias foo (fun(tbl: any): (number, integer))

---@class bar
---@overload fun(tbl: any): (number, integer)

---@type foo
local b = {}

---@type bar
local c = {}

for k, v in b do
    -- k is inferred as number
    -- v is inferred as string
end

for k, v in c do
    -- k is also inferred as number
    -- v is also inferred as string
end
```
