### PR TITLE
Support lazydev.nvim

### DIFF
--- a/crates/emmylua_ls/src/handlers/initialized/client_config/neovim_config.rs
+++ b/crates/emmylua_ls/src/handlers/initialized/client_config/neovim_config.rs
@@ -4,6 +4,7 @@ use log::info;
 use serde_json::Value;
 
 use crate::{context::ServerContextSnapshot, util::time_cancel_token};
+use emmylua_code_analysis::file_path_to_uri;
 
 use super::ClientConfig;
 
@@ -11,10 +12,18 @@ pub async fn get_client_config_neovim(
     context: &ServerContextSnapshot,
     config: &mut ClientConfig,
 ) -> Option<()> {
+    let workspace_folders = context
+        .workspace_manager
+        .read()
+        .await
+        .workspace_folders
+        .clone();
+    let main_workspace_folder = workspace_folders.get(0);
     let client = &context.client;
+    let scope_uri = main_workspace_folder.map(|p| file_path_to_uri(p).unwrap());
     let params = lsp_types::ConfigurationParams {
         items: vec![lsp_types::ConfigurationItem {
-            scope_uri: None,
+            scope_uri: scope_uri,
             section: Some("Lua".to_string()),
         }],
     };


### PR DESCRIPTION
`scopeUri` is expected by lazydev.nvim

the `clone`-ing of workspace folders and `unwrap()` could be re-worked, but it works (as long as lazydev does its part, which isn't the case rn)

xref https://github.com/folke/lazydev.nvim/issues/86