### PR TITLE
Diagnostics for unnecessary assert

### DIFF
--- a/crates/emmylua_code_analysis/locales/lint.yml
+++ b/crates/emmylua_code_analysis/locales/lint.yml
@@ -205,3 +205,7 @@ Cannot use `...` outside a vararg function.:
   en: "Async function can only be called in async function."
   zh_CN: "只能在标记为异步的函数中调用异步函数。"
   zh_HK: "只能在標記為非同步的函式中呼叫非同步函式。"
+'Unnecessary assert: this expression is always truthy':
+  en: 'Unnecessary assert: this expression is always truthy'
+  zh_CN: '不必要的断言: 这个表达式始终为真'
+  zh_HK: '唔需要嘅斷言: 呢個表達式永遠都係真'

--- a/crates/emmylua_code_analysis/resources/schema.json
+++ b/crates/emmylua_code_analysis/resources/schema.json
@@ -430,6 +430,34 @@
           "enum": [
             "missing-global-doc"
           ]
+        },
+        {
+          "description": "Assign type mismatch",
+          "type": "string",
+          "enum": [
+            "assign-type-mismatch"
+          ]
+        },
+        {
+          "description": "Duplicate require",
+          "type": "string",
+          "enum": [
+            "duplicate-require"
+          ]
+        },
+        {
+          "description": "non-literal-expressions-in-assert",
+          "type": "string",
+          "enum": [
+            "non-literal-expressions-in-assert"
+          ]
+        },
+        {
+          "description": "unnecessary-assert",
+          "type": "string",
+          "enum": [
+            "unnecessary-assert"
+          ]
         }
       ]
     },

--- a/crates/emmylua_code_analysis/src/db_index/type/types.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/types.rs
@@ -272,6 +272,19 @@ impl LuaType {
         }
     }
 
+    pub fn is_always_truthy(&self) -> bool {
+        match self {
+            LuaType::Nullable(_)
+            | LuaType::Nil
+            | LuaType::Boolean
+            | LuaType::Any
+            | LuaType::Unknown => false,
+            LuaType::BooleanConst(boolean) | LuaType::DocBooleanConst(boolean) => boolean.clone(),
+            LuaType::Union(u) => u.types.iter().all(|t| t.is_always_truthy()),
+            _ => true,
+        }
+    }
+
     pub fn is_tuple(&self) -> bool {
         matches!(self, LuaType::Tuple(_))
     }

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/mod.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/mod.rs
@@ -24,6 +24,7 @@ mod syntax_error;
 mod unbalanced_assignments;
 mod undefined_doc_param;
 mod undefined_global;
+mod unnecessary_assert;
 mod unused;
 
 use code_style::check_file_code_style;
@@ -61,6 +62,7 @@ pub fn check_file(context: &mut DiagnosticContext, semantic_model: &SemanticMode
     check!(unused);
     check!(deprecated);
     check!(undefined_global);
+    check!(unnecessary_assert);
     check!(access_invisible);
     check!(missing_parameter);
     check!(redundant_parameter);

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/unnecessary_assert.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/unnecessary_assert.rs
@@ -1,0 +1,39 @@
+use emmylua_parser::{LuaAstNode, LuaCallExpr};
+
+use crate::{DiagnosticCode, SemanticModel};
+
+use super::DiagnosticContext;
+
+pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::UnnecessaryAssert];
+
+pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
+    let root = semantic_model.get_root().clone();
+    for call_expr in root.descendants::<LuaCallExpr>() {
+        if call_expr.is_assert() {
+            check_assert_rule(context, semantic_model, call_expr);
+        }
+    }
+
+    Some(())
+}
+
+fn check_assert_rule(
+    context: &mut DiagnosticContext,
+    semantic_model: &SemanticModel,
+    call_expr: LuaCallExpr,
+) -> Option<()> {
+    let args = call_expr.get_args_list()?;
+    let arg_exprs = args.get_args().collect::<Vec<_>>();
+    if let Some(first_expr) = arg_exprs.first() {
+        let expr_type = semantic_model.infer_expr(first_expr.clone());
+        if expr_type.is_some_and(|t| t.is_always_truthy()) {
+            context.add_diagnostic(
+                DiagnosticCode::UnnecessaryAssert,
+                call_expr.get_range(),
+                t!("Unnecessary assert: this expression is always truthy").to_string(),
+                None,
+            );
+        }
+    }
+    Some(())
+}

--- a/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic_code.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic_code.rs
@@ -88,6 +88,8 @@ pub enum DiagnosticCode {
     NonLiteralExpressionsInAssert,
     /// Unbalanced assignments
     UnbalancedAssignments,
+    /// unnecessary-assert
+    UnnecessaryAssert,
 
     #[serde(other)]
     None,


### PR DESCRIPTION
Warns on unnecessary assertions (on expressions that always evaluate to `true`):

![image](https://github.com/user-attachments/assets/9cdeaf4c-bd6b-443b-851a-c71842e3aebd)

![image](https://github.com/user-attachments/assets/e2a0aef2-a0d4-48ce-a820-efbea82097e0)

I might need help with tests and i18n. Also, this does not work for aliases, I couldn't figure out why:

![image](https://github.com/user-attachments/assets/6d1cadf2-4f52-414a-876f-64bcd4e198a9)
