### PR TITLE
Refactor: migrate diagnostics to use trait rather than macro

### DIFF
--- a/crates/emmylua_code_analysis/src/diagnostic/checker/access_invisible.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/access_invisible.rs
@@ -6,25 +6,27 @@ use crate::{
     SemanticModel,
 };
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::AccessInvisible];
+pub struct AccessInvisibleChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    for node in root.descendants::<LuaAst>() {
-        match node {
-            LuaAst::LuaNameExpr(name_expr) => {
-                check_name_expr(context, semantic_model, name_expr);
+impl Checker for AccessInvisibleChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::AccessInvisible];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        for node in root.descendants::<LuaAst>() {
+            match node {
+                LuaAst::LuaNameExpr(name_expr) => {
+                    check_name_expr(context, semantic_model, name_expr);
+                }
+                LuaAst::LuaIndexExpr(index_expr) => {
+                    check_index_expr(context, semantic_model, index_expr);
+                }
+                _ => {}
             }
-            LuaAst::LuaIndexExpr(index_expr) => {
-                check_index_expr(context, semantic_model, index_expr);
-            }
-            _ => {}
         }
     }
-
-    Some(())
 }
 
 fn check_name_expr(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
@@ -9,23 +9,26 @@ use crate::{
     TypeCheckFailReason, TypeCheckResult,
 };
 
-use super::{humanize_lint_type, DiagnosticContext};
+use super::{humanize_lint_type, Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::AssignTypeMismatch];
+pub struct AssignTypeMismatchChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    for node in semantic_model.get_root().descendants::<LuaAst>() {
-        match node {
-            LuaAst::LuaAssignStat(assign) => {
-                check_assign_stat(context, semantic_model, &assign);
+impl Checker for AssignTypeMismatchChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::AssignTypeMismatch];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        for node in semantic_model.get_root().descendants::<LuaAst>() {
+            match node {
+                LuaAst::LuaAssignStat(assign) => {
+                    check_assign_stat(context, semantic_model, &assign);
+                }
+                LuaAst::LuaLocalStat(local) => {
+                    check_local_stat(context, semantic_model, &local);
+                }
+                _ => {}
             }
-            LuaAst::LuaLocalStat(local) => {
-                check_local_stat(context, semantic_model, &local);
-            }
-            _ => {}
         }
     }
-    Some(())
 }
 
 fn check_assign_stat(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/await_in_sync.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/await_in_sync.rs
@@ -2,18 +2,20 @@ use emmylua_parser::{LuaAstNode, LuaCallArgList, LuaCallExpr, LuaClosureExpr, Lu
 
 use crate::{DiagnosticCode, LuaSignatureId, LuaType, SemanticModel};
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::AwaitInSync];
+pub struct AwaitInSyncChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    for call_expr in root.descendants::<LuaCallExpr>() {
-        check_call_expr(context, semantic_model, call_expr.clone());
-        check_pcall_or_xpcall(context, semantic_model, call_expr);
+impl Checker for AwaitInSyncChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::AwaitInSync];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        for call_expr in root.descendants::<LuaCallExpr>() {
+            check_call_expr(context, semantic_model, call_expr.clone());
+            check_pcall_or_xpcall(context, semantic_model, call_expr);
+        }
     }
-
-    Some(())
 }
 
 fn check_call_expr(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/check_field.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/check_field.rs
@@ -4,44 +4,47 @@ use emmylua_parser::{LuaAst, LuaAstNode, LuaIndexExpr, LuaIndexKey, LuaVarExpr};
 
 use crate::{DiagnosticCode, LuaType, SemanticModel};
 
-use super::{humanize_lint_type, DiagnosticContext};
+use super::{humanize_lint_type, Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::InjectField, DiagnosticCode::UndefinedField];
+pub struct CheckFieldChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    let mut checked_index_expr = HashSet::new();
-    for node in root.descendants::<LuaAst>() {
-        match node {
-            LuaAst::LuaAssignStat(assign) => {
-                let (vars, _) = assign.get_var_and_expr_list();
-                for var in vars.iter() {
-                    if let LuaVarExpr::IndexExpr(index_expr) = var {
-                        checked_index_expr.insert(index_expr.syntax().clone());
-                        check_index_expr(
-                            context,
-                            semantic_model,
-                            index_expr,
-                            DiagnosticCode::InjectField,
-                        );
+impl Checker for CheckFieldChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::InjectField, DiagnosticCode::UndefinedField];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        let mut checked_index_expr = HashSet::new();
+        for node in root.descendants::<LuaAst>() {
+            match node {
+                LuaAst::LuaAssignStat(assign) => {
+                    let (vars, _) = assign.get_var_and_expr_list();
+                    for var in vars.iter() {
+                        if let LuaVarExpr::IndexExpr(index_expr) = var {
+                            checked_index_expr.insert(index_expr.syntax().clone());
+                            check_index_expr(
+                                context,
+                                semantic_model,
+                                index_expr,
+                                DiagnosticCode::InjectField,
+                            );
+                        }
                     }
                 }
-            }
-            LuaAst::LuaIndexExpr(index_expr) => {
-                if checked_index_expr.contains(index_expr.syntax()) {
-                    continue;
+                LuaAst::LuaIndexExpr(index_expr) => {
+                    if checked_index_expr.contains(index_expr.syntax()) {
+                        continue;
+                    }
+                    check_index_expr(
+                        context,
+                        semantic_model,
+                        &index_expr,
+                        DiagnosticCode::UndefinedField,
+                    );
                 }
-                check_index_expr(
-                    context,
-                    semantic_model,
-                    &index_expr,
-                    DiagnosticCode::UndefinedField,
-                );
+                _ => {}
             }
-            _ => {}
         }
     }
-    Some(())
 }
 
 fn check_index_expr(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/check_param_count.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/check_param_count.rs
@@ -5,27 +5,29 @@ use emmylua_parser::{
 
 use crate::{DiagnosticCode, LuaSignatureId, LuaType, SemanticModel};
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[
-    DiagnosticCode::MissingParameter,
-    DiagnosticCode::RedundantParameter,
-];
+pub struct CheckParamCountChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    for node in semantic_model.get_root().descendants::<LuaAst>() {
-        match node {
-            LuaAst::LuaCallExpr(call_expr) => {
-                check_call_expr(context, semantic_model, call_expr);
+impl Checker for CheckParamCountChecker {
+    const CODES: &[DiagnosticCode] = &[
+        DiagnosticCode::MissingParameter,
+        DiagnosticCode::RedundantParameter,
+    ];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        for node in semantic_model.get_root().descendants::<LuaAst>() {
+            match node {
+                LuaAst::LuaCallExpr(call_expr) => {
+                    check_call_expr(context, semantic_model, call_expr);
+                }
+                LuaAst::LuaClosureExpr(closure_expr) => {
+                    check_closure_expr(context, semantic_model, &closure_expr);
+                }
+                _ => {}
             }
-            LuaAst::LuaClosureExpr(closure_expr) => {
-                check_closure_expr(context, semantic_model, &closure_expr);
-            }
-            _ => {}
         }
     }
-
-    Some(())
 }
 
 /// 处理左值已绑定类型但右值为匿名函数的情况

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/check_return_count.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/check_return_count.rs
@@ -5,21 +5,24 @@ use emmylua_parser::{
 
 use crate::{DiagnosticCode, LuaSignatureId, LuaType, SemanticModel, SignatureReturnStatus};
 
-use super::{get_own_return_stats, DiagnosticContext};
+use super::{get_own_return_stats, Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[
-    DiagnosticCode::RedundantReturnValue,
-    DiagnosticCode::MissingReturnValue,
-    DiagnosticCode::MissingReturn,
-];
+pub struct CheckReturnCount;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
+impl Checker for CheckReturnCount {
+    const CODES: &[DiagnosticCode] = &[
+        DiagnosticCode::RedundantReturnValue,
+        DiagnosticCode::MissingReturnValue,
+        DiagnosticCode::MissingReturn,
+    ];
 
-    for closure_expr in root.descendants::<LuaClosureExpr>() {
-        check_missing_return(context, semantic_model, &closure_expr);
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+
+        for closure_expr in root.descendants::<LuaClosureExpr>() {
+            check_missing_return(context, semantic_model, &closure_expr);
+        }
     }
-    Some(())
 }
 
 // 获取(是否doc标注过返回值, 返回值类型)

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/circle_doc_class.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/circle_doc_class.rs
@@ -3,18 +3,21 @@ use rowan::TextRange;
 
 use crate::{DiagnosticCode, LuaType, SemanticModel};
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::CircleDocClass];
+pub struct CircleDocClassChecker;
 
-/// 检查循环继承的类
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
+impl Checker for CircleDocClassChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::CircleDocClass];
 
-    for expr in root.descendants::<LuaDocTagClass>() {
-        check_doc_tag_class(context, semantic_model, &expr);
+    /// 检查循环继承的类
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+
+        for expr in root.descendants::<LuaDocTagClass>() {
+            check_doc_tag_class(context, semantic_model, &expr);
+        }
     }
-    Some(())
 }
 
 fn check_doc_tag_class(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/code_style_check.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/code_style_check.rs
@@ -3,29 +3,35 @@ use rowan::TextRange;
 
 use crate::{DiagnosticCode, SemanticModel};
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::CodeStyleCheck];
+pub struct CodeStyleCheckChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let document = semantic_model.get_document();
-    let file_path = document.get_file_path();
-    let text = document.get_text();
-    let result = check_code_style(&file_path.to_string_lossy().to_string(), text);
-    for diagnostic in result {
-        let start = document.get_offset(
-            diagnostic.start_line as usize,
-            diagnostic.start_col as usize,
-        )?;
-        let end = document.get_offset(diagnostic.end_line as usize, diagnostic.end_col as usize)?;
-        let text_range = TextRange::new(start, end);
-        context.add_diagnostic(
-            DiagnosticCode::CodeStyleCheck,
-            text_range,
-            diagnostic.message,
-            None,
-        );
+impl Checker for CodeStyleCheckChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::CodeStyleCheck];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let document = semantic_model.get_document();
+        let file_path = document.get_file_path();
+        let text = document.get_text();
+        let result = check_code_style(&file_path.to_string_lossy().to_string(), text);
+        for diagnostic in result {
+            let (Some(start), Some(end)) = (
+                document.get_offset(
+                    diagnostic.start_line as usize,
+                    diagnostic.start_col as usize,
+                ),
+                document.get_offset(diagnostic.end_line as usize, diagnostic.end_col as usize),
+            ) else {
+                return;
+            };
+            let text_range = TextRange::new(start, end);
+            context.add_diagnostic(
+                DiagnosticCode::CodeStyleCheck,
+                text_range,
+                diagnostic.message,
+                None,
+            );
+        }
     }
-
-    Some(())
 }

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/deprecated.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/deprecated.rs
@@ -4,25 +4,27 @@ use crate::{
     DiagnosticCode, LuaDeclId, LuaMemberId, LuaSemanticDeclId, SemanticDeclLevel, SemanticModel,
 };
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::Unused];
+pub struct DeprecatedChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    for node in root.descendants::<LuaAst>() {
-        match node {
-            LuaAst::LuaNameExpr(name_expr) => {
-                check_name_expr(context, semantic_model, name_expr);
+impl Checker for DeprecatedChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::Unused];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        for node in root.descendants::<LuaAst>() {
+            match node {
+                LuaAst::LuaNameExpr(name_expr) => {
+                    check_name_expr(context, semantic_model, name_expr);
+                }
+                LuaAst::LuaIndexExpr(index_expr) => {
+                    check_index_expr(context, semantic_model, index_expr);
+                }
+                _ => {}
             }
-            LuaAst::LuaIndexExpr(index_expr) => {
-                check_index_expr(context, semantic_model, index_expr);
-            }
-            _ => {}
         }
     }
-
-    Some(())
 }
 
 fn check_name_expr(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/discard_returns.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/discard_returns.rs
@@ -3,17 +3,19 @@ use rowan::NodeOrToken;
 
 use crate::{DiagnosticCode, LuaSemanticDeclId, SemanticDeclLevel, SemanticModel};
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::DiscardReturns];
+pub struct DiscardReturnsChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    for call_expr_stat in root.descendants::<LuaCallExprStat>() {
-        check_call_expr(context, semantic_model, call_expr_stat);
+impl Checker for DiscardReturnsChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::DiscardReturns];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        for call_expr_stat in root.descendants::<LuaCallExprStat>() {
+            check_call_expr(context, semantic_model, call_expr_stat);
+        }
     }
-
-    Some(())
 }
 
 fn check_call_expr(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/duplicate_require.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/duplicate_require.rs
@@ -3,20 +3,22 @@ use rowan::TextRange;
 
 use crate::{DiagnosticCode, LuaType, SemanticModel};
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::DuplicateRequire];
+pub struct DuplicateRequireChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    let mut require_calls = Vec::new();
-    for call_expr in root.descendants::<LuaCallExpr>() {
-        if call_expr.is_require() {
-            check_require_call_expr(context, semantic_model, call_expr, &mut require_calls);
+impl Checker for DuplicateRequireChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::DuplicateRequire];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        let mut require_calls = Vec::new();
+        for call_expr in root.descendants::<LuaCallExpr>() {
+            if call_expr.is_require() {
+                check_require_call_expr(context, semantic_model, call_expr, &mut require_calls);
+            }
         }
     }
-
-    Some(())
 }
 
 fn check_require_call_expr(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/duplicate_type.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/duplicate_type.rs
@@ -4,27 +4,30 @@ use emmylua_parser::{
 
 use crate::{DiagnosticCode, LuaTypeAttribute, SemanticModel};
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::DuplicateType];
+pub struct DuplicateTypeChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    for tag in root.descendants::<LuaDocTag>() {
-        match tag {
-            LuaDocTag::Class(class_tag) => {
-                check_duplicate_class(context, class_tag);
+impl Checker for DuplicateTypeChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::DuplicateType];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        for tag in root.descendants::<LuaDocTag>() {
+            match tag {
+                LuaDocTag::Class(class_tag) => {
+                    check_duplicate_class(context, class_tag);
+                }
+                LuaDocTag::Enum(enum_tag) => {
+                    check_duplicate_enum(context, enum_tag);
+                }
+                LuaDocTag::Alias(alias_tag) => {
+                    check_duplicate_alias(context, alias_tag);
+                }
+                _ => {}
             }
-            LuaDocTag::Enum(enum_tag) => {
-                check_duplicate_enum(context, enum_tag);
-            }
-            LuaDocTag::Alias(alias_tag) => {
-                check_duplicate_alias(context, alias_tag);
-            }
-            _ => {}
         }
     }
-    Some(())
 }
 
 fn check_duplicate_class(context: &mut DiagnosticContext, class_tag: LuaDocTagClass) -> Option<()> {

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/incomplete_signature_doc.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/incomplete_signature_doc.rs
@@ -4,19 +4,22 @@ use emmylua_parser::{LuaAstNode, LuaClosureExpr, LuaDocTagParam, LuaDocTagReturn
 
 use crate::{DiagnosticCode, LuaSemanticDeclId, LuaType, SemanticDeclLevel, SemanticModel};
 
-use super::{get_closure_expr_comment, get_own_return_stats, DiagnosticContext};
+use super::{get_closure_expr_comment, get_own_return_stats, Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[
-    DiagnosticCode::IncompleteSignatureDoc,
-    DiagnosticCode::MissingGlobalDoc,
-];
+pub struct IncompleteSignatureDocChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root();
-    for closure_expr in root.descendants::<LuaClosureExpr>() {
-        check_doc(context, semantic_model, &closure_expr);
+impl Checker for IncompleteSignatureDocChecker {
+    const CODES: &[DiagnosticCode] = &[
+        DiagnosticCode::IncompleteSignatureDoc,
+        DiagnosticCode::MissingGlobalDoc,
+    ];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root();
+        for closure_expr in root.descendants::<LuaClosureExpr>() {
+            check_doc(context, semantic_model, &closure_expr);
+        }
     }
-    Some(())
 }
 
 fn check_doc(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/missing_fields.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/missing_fields.rs
@@ -4,19 +4,22 @@ use emmylua_parser::{LuaAstNode, LuaTableExpr};
 
 use crate::{DiagnosticCode, LuaMemberOwner, LuaType, LuaTypeDeclId, SemanticModel};
 
-use super::{humanize_lint_type, DiagnosticContext};
+use super::{humanize_lint_type, Checker, DiagnosticContext};
 use itertools::Itertools;
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::MissingFields];
+pub struct MissingFieldsChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
+impl Checker for MissingFieldsChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::MissingFields];
 
-    let mut type_cache = HashMap::new();
-    for expr in root.descendants::<LuaTableExpr>() {
-        check_table_expr(context, semantic_model, &expr, &mut type_cache);
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+
+        let mut type_cache = HashMap::new();
+        for expr in root.descendants::<LuaTableExpr>() {
+            check_table_expr(context, semantic_model, &expr, &mut type_cache);
+        }
     }
-    Some(())
 }
 
 fn check_table_expr(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/mod.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/mod.rs
@@ -44,44 +44,48 @@ use super::{
     DiagnosticCode,
 };
 
-pub fn check_file(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    macro_rules! check {
-        ($module:ident) => {
-            if $module::CODES
-                .iter()
-                .any(|code| context.is_checker_enable_by_code(code))
-            {
-                $module::check(context, semantic_model);
-            }
-        };
-    }
+pub trait Checker {
+    const CODES: &[DiagnosticCode];
 
-    check!(syntax_error);
-    check!(analyze_error);
-    check!(unused);
-    check!(deprecated);
-    check!(undefined_global);
-    check!(unnecessary_assert);
-    check!(access_invisible);
-    check!(local_const_reassign);
-    check!(discard_returns);
-    check!(await_in_sync);
-    check!(param_type_check);
-    check!(need_check_nil);
-    check!(code_style_check);
-    check!(return_type_mismatch);
-    check!(undefined_doc_param);
-    check!(redefined_local);
-    check!(missing_fields);
-    check!(check_field);
-    check!(circle_doc_class);
-    check!(incomplete_signature_doc);
-    check!(assign_type_mismatch);
-    check!(duplicate_require);
-    check!(duplicate_type);
-    check!(check_return_count);
-    check!(unbalanced_assignments);
-    check!(check_param_count);
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel);
+}
+
+fn run_check<T: Checker>(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+    if T::CODES
+        .iter()
+        .any(|code| context.is_checker_enable_by_code(code))
+    {
+        T::check(context, semantic_model);
+    }
+}
+
+pub fn check_file(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
+    run_check::<syntax_error::SyntaxErrorChecker>(context, semantic_model);
+    run_check::<analyze_error::AnalyzeErrorChecker>(context, semantic_model);
+    run_check::<unused::UnusedChecker>(context, semantic_model);
+    run_check::<deprecated::DeprecatedChecker>(context, semantic_model);
+    run_check::<undefined_global::UndefinedGlobalChecker>(context, semantic_model);
+    run_check::<unnecessary_assert::UnnecessaryAssertChecker>(context, semantic_model);
+    run_check::<access_invisible::AccessInvisibleChecker>(context, semantic_model);
+    run_check::<local_const_reassign::LocalConstReassignChecker>(context, semantic_model);
+    run_check::<discard_returns::DiscardReturnsChecker>(context, semantic_model);
+    run_check::<await_in_sync::AwaitInSyncChecker>(context, semantic_model);
+    run_check::<param_type_check::ParamTypeCheckChecker>(context, semantic_model);
+    run_check::<need_check_nil::NeedCheckNilChecker>(context, semantic_model);
+    run_check::<code_style_check::CodeStyleCheckChecker>(context, semantic_model);
+    run_check::<return_type_mismatch::ReturnTypeMismatch>(context, semantic_model);
+    run_check::<undefined_doc_param::UndefinedDocParamChecker>(context, semantic_model);
+    run_check::<redefined_local::RedefinedLocalChecker>(context, semantic_model);
+    run_check::<missing_fields::MissingFieldsChecker>(context, semantic_model);
+    run_check::<check_field::CheckFieldChecker>(context, semantic_model);
+    run_check::<circle_doc_class::CircleDocClassChecker>(context, semantic_model);
+    run_check::<incomplete_signature_doc::IncompleteSignatureDocChecker>(context, semantic_model);
+    run_check::<assign_type_mismatch::AssignTypeMismatchChecker>(context, semantic_model);
+    run_check::<duplicate_require::DuplicateRequireChecker>(context, semantic_model);
+    run_check::<duplicate_type::DuplicateTypeChecker>(context, semantic_model);
+    run_check::<check_return_count::CheckReturnCount>(context, semantic_model);
+    run_check::<unbalanced_assignments::UnbalancedAssignmentsChecker>(context, semantic_model);
+    run_check::<check_param_count::CheckParamCountChecker>(context, semantic_model);
 
     check_file_code_style(context, semantic_model);
     Some(())

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/need_check_nil.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/need_check_nil.rs
@@ -4,28 +4,30 @@ use emmylua_parser::{
 
 use crate::{DiagnosticCode, SemanticModel};
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::NeedCheckNil];
+pub struct NeedCheckNilChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    for expr in root.descendants::<LuaExpr>() {
-        match expr {
-            LuaExpr::CallExpr(call_expr) => {
-                check_call_expr(context, semantic_model, call_expr);
+impl Checker for NeedCheckNilChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::NeedCheckNil];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        for expr in root.descendants::<LuaExpr>() {
+            match expr {
+                LuaExpr::CallExpr(call_expr) => {
+                    check_call_expr(context, semantic_model, call_expr);
+                }
+                LuaExpr::BinaryExpr(binary_expr) => {
+                    check_binary_expr(context, semantic_model, binary_expr);
+                }
+                LuaExpr::IndexExpr(index_expr) => {
+                    check_index_expr(context, semantic_model, index_expr);
+                }
+                _ => {}
             }
-            LuaExpr::BinaryExpr(binary_expr) => {
-                check_binary_expr(context, semantic_model, binary_expr);
-            }
-            LuaExpr::IndexExpr(index_expr) => {
-                check_index_expr(context, semantic_model, index_expr);
-            }
-            _ => {}
         }
     }
-
-    Some(())
 }
 
 fn check_call_expr(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/param_type_check.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/param_type_check.rs
@@ -6,23 +6,25 @@ use crate::{
     TypeCheckResult,
 };
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::ParamTypeNotMatch];
+pub struct ParamTypeCheckChecker;
 
-/// a simple implementation of param type check, later we will do better
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    for node in root.descendants::<LuaAst>() {
-        match node {
-            LuaAst::LuaCallExpr(call_expr) => {
-                check_call_expr(context, semantic_model, call_expr);
+impl Checker for ParamTypeCheckChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::ParamTypeNotMatch];
+
+    /// a simple implementation of param type check, later we will do better
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        for node in root.descendants::<LuaAst>() {
+            match node {
+                LuaAst::LuaCallExpr(call_expr) => {
+                    check_call_expr(context, semantic_model, call_expr);
+                }
+                _ => {}
             }
-            _ => {}
         }
     }
-
-    Some(())
 }
 
 fn check_call_expr(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/return_type_mismatch.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/return_type_mismatch.rs
@@ -6,16 +6,19 @@ use crate::{
     SignatureReturnStatus, TypeCheckFailReason, TypeCheckResult,
 };
 
-use super::{get_own_return_stats, DiagnosticContext};
+use super::{get_own_return_stats, Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::ReturnTypeMismatch];
+pub struct ReturnTypeMismatch;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    for closure_expr in root.descendants::<LuaClosureExpr>() {
-        check_closure_expr(context, semantic_model, &closure_expr);
+impl Checker for ReturnTypeMismatch {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::ReturnTypeMismatch];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        for closure_expr in root.descendants::<LuaClosureExpr>() {
+            check_closure_expr(context, semantic_model, &closure_expr);
+        }
     }
-    Some(())
 }
 
 fn check_closure_expr(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/unbalanced_assignments.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/unbalanced_assignments.rs
@@ -2,25 +2,27 @@ use emmylua_parser::{LuaAssignStat, LuaAstNode, LuaExpr, LuaLocalStat, LuaStat};
 
 use crate::{DiagnosticCode, SemanticModel};
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::UnbalancedAssignments];
+pub struct UnbalancedAssignmentsChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    for stat in root.descendants::<LuaStat>() {
-        match stat {
-            LuaStat::LocalStat(local) => {
-                check_local_stat(context, semantic_model, &local);
+impl Checker for UnbalancedAssignmentsChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::UnbalancedAssignments];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        for stat in root.descendants::<LuaStat>() {
+            match stat {
+                LuaStat::LocalStat(local) => {
+                    check_local_stat(context, semantic_model, &local);
+                }
+                LuaStat::AssignStat(assign) => {
+                    check_assign_stat(context, semantic_model, &assign);
+                }
+                _ => {}
             }
-            LuaStat::AssignStat(assign) => {
-                check_assign_stat(context, semantic_model, &assign);
-            }
-            _ => {}
         }
     }
-
-    Some(())
 }
 
 fn check_assign_stat(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/undefined_doc_param.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/undefined_doc_param.rs
@@ -2,16 +2,19 @@ use emmylua_parser::{LuaAstNode, LuaAstToken, LuaClosureExpr, LuaDocTagParam};
 
 use crate::{DiagnosticCode, LuaSignatureId, SemanticModel};
 
-use super::{get_closure_expr_comment, DiagnosticContext};
+use super::{get_closure_expr_comment, Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::UndefinedDocParam];
+pub struct UndefinedDocParamChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    for closure_expr in root.descendants::<LuaClosureExpr>() {
-        check_doc_param(context, semantic_model, &closure_expr);
+impl Checker for UndefinedDocParamChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::UndefinedDocParam];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        for closure_expr in root.descendants::<LuaClosureExpr>() {
+            check_doc_param(context, semantic_model, &closure_expr);
+        }
     }
-    Some(())
 }
 
 fn check_doc_param(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/undefined_global.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/undefined_global.rs
@@ -5,19 +5,21 @@ use rowan::TextRange;
 
 use crate::{DiagnosticCode, LuaMemberKey, LuaSignatureId, SemanticModel};
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::UndefinedGlobal];
+pub struct UndefinedGlobalChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    let mut use_range_set = HashSet::new();
-    calc_name_expr_ref(semantic_model, &mut use_range_set);
-    for name_expr in root.descendants::<LuaNameExpr>() {
-        check_name_expr(context, semantic_model, &mut use_range_set, name_expr);
+impl Checker for UndefinedGlobalChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::UndefinedGlobal];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        let mut use_range_set = HashSet::new();
+        calc_name_expr_ref(semantic_model, &mut use_range_set);
+        for name_expr in root.descendants::<LuaNameExpr>() {
+            check_name_expr(context, semantic_model, &mut use_range_set, name_expr);
+        }
     }
-
-    Some(())
 }
 
 fn calc_name_expr_ref(

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/unnecessary_assert.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/unnecessary_assert.rs
@@ -2,19 +2,21 @@ use emmylua_parser::{LuaAstNode, LuaCallExpr};
 
 use crate::{DiagnosticCode, LuaType, SemanticModel};
 
-use super::DiagnosticContext;
+use super::{Checker, DiagnosticContext};
 
-pub const CODES: &[DiagnosticCode] = &[DiagnosticCode::UnnecessaryAssert];
+pub struct UnnecessaryAssertChecker;
 
-pub fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) -> Option<()> {
-    let root = semantic_model.get_root().clone();
-    for call_expr in root.descendants::<LuaCallExpr>() {
-        if call_expr.is_assert() {
-            check_assert_rule(context, semantic_model, call_expr);
+impl Checker for UnnecessaryAssertChecker {
+    const CODES: &[DiagnosticCode] = &[DiagnosticCode::UnnecessaryAssert];
+
+    fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
+        let root = semantic_model.get_root().clone();
+        for call_expr in root.descendants::<LuaCallExpr>() {
+            if call_expr.is_assert() {
+                check_assert_rule(context, semantic_model, call_expr);
+            }
         }
     }
-
-    Some(())
 }
 
 fn check_assert_rule(


### PR DESCRIPTION
This commit makes it so that diagnostic checkers no longer have to define magic public variables which will be called by a macro. Instead, they all implement a common trait which will easily enforce that all the checking data is defined. This also means compile errors will be quicker and more understandable.