### PR TITLE
fix: stdlib remove some overloads

### DIFF
--- a/crates/emmylua_code_analysis/resources/std/global.lua
+++ b/crates/emmylua_code_analysis/resources/std/global.lua
@@ -73,8 +73,7 @@ function collectgarbage(opt, ...) end
 --- (`stdin`). Returns all values returned by the chunk. In case of errors,
 --- `dofile` propagates the error to its caller (that is, `dofile` does not run
 --- in protected mode).
----@overload fun():table
----@param filename string
+---@param filename? string
 ---@return table
 function dofile(filename) end
 

--- a/crates/emmylua_code_analysis/resources/std/io.lua
+++ b/crates/emmylua_code_analysis/resources/std/io.lua
@@ -249,9 +249,8 @@ function file:seek(whence, offset) end
 ---
 --- For the last two cases, `size` specifies the size of the buffer, in
 --- bytes. The default is an appropriate size.
----@overload fun(mode:string)
 ---@param mode string | 'no' | 'full' | 'line'
----@param size integer
+---@param size? integer
 function file:setvbuf(mode, size) end
 
 ---

--- a/crates/emmylua_code_analysis/resources/std/math.lua
+++ b/crates/emmylua_code_analysis/resources/std/math.lua
@@ -42,9 +42,8 @@ function math.asin(x) end
 ---
 --- The default value for `x` is 1, so that the call `math.atan(y)`` returns the
 --- arc tangent of `y`.
----@overload fun(y:number):number
 ---@param y number
----@param x number
+---@param x? number
 ---@return number
 function math.atan(y, x) end
 
@@ -94,7 +93,6 @@ math.huge = nil
 ---
 --- Returns the logarithm of `x` in the given base. The default for `base` is
 --- *e* (so that the function returns the natural logarithm of `x`).
----@overload fun(x:number):number
 ---@param x number
 ---@param base? number
 ---@return number

--- a/crates/emmylua_code_analysis/resources/std/os.lua
+++ b/crates/emmylua_code_analysis/resources/std/os.lua
@@ -176,7 +176,6 @@ function os.rename(oldname, newname) end
 ---
 --- This function may be not thread safe because of its reliance on C function
 --- `setlocale`.
----@overload fun(locale:string):string?
 ---@param locale string
 ---@param category? string
 ---@return string|nil

--- a/crates/emmylua_code_analysis/resources/std/package.lua
+++ b/crates/emmylua_code_analysis/resources/std/package.lua
@@ -163,7 +163,6 @@ package.searchers = {}
 --- Returns the resulting name of the first file that it can open in read mode
 --- (after closing the file), or **nil** plus an error message if none succeeds.
 --- (This error message lists all file names it tried to open.)
----@overload fun(name:string, path:string):string
 ---@param name string
 ---@param path? string
 ---@param sep? string

--- a/crates/emmylua_code_analysis/resources/std/string.lua
+++ b/crates/emmylua_code_analysis/resources/std/string.lua
@@ -28,7 +28,6 @@ string = {}
 --- `string.sub`.
 ---
 --- Note that numerical codes are not necessarily portable across platforms.
----@overload fun(s:string):integer
 ---@param s string
 ---@param i? integer
 ---@param j? integer
@@ -191,7 +190,6 @@ function string.gmatch(s, pattern) end
 --- `local t = {name="lua", version="5.3"}`
 --- `x = string.gsub("$name-$version.tar.gz", "%$(%w+)", t)`
 --- > x="lua-5.3.tar.gz"
----@overload fun(s:string, pattern:string, repl:string|fun()):string, integer
 ---@param s string
 ---@param pattern string
 ---@param repl string|fun(param:string)
@@ -252,7 +250,6 @@ function string.packsize(fmt) end
 ---
 --- Note that it is very easy to exhaust the memory of your machine with a
 --- single call to this function.
----@overload fun(s:string, n:integer):string
 ---@param s string
 ---@param n integer
 ---@param sep? string
@@ -289,7 +286,6 @@ function string.sub(s, i, j) end
 --- `fmt`. An optional `pos` marks where to start reading in `s` (default is 1).
 --- After the read values, this function also returns the index of the first
 --- unread byte in `s`.
----@overload fun(fmt:string, s:string):string
 ---@param fmt string
 ---@param s string
 ---@param pos? integer


### PR DESCRIPTION
Not sure why these were added, but they shouldn't be necessary.
